### PR TITLE
Update tokens.json

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -145,6 +145,15 @@
       "decimals": 6,
       "address": "0x4A771Cc1a39FDd8AA08B8EA51F7Fd412e73B3d2B",
       "logoURI": "https://raw.githubusercontent.com/blazeswap/default-lists/main/assets/USDX.png"
+   },
+   {
+      "chainId": 14,
+      "name": "FlareFrog",
+      "symbol": "FLRFROG",
+      "decimals": 18,
+      "address": "0x19cf770bbb7b71977b860e7fd8d32fa2513a743c",
+      "logoURI": "https://avatars.githubusercontent.com/u/200678700?s=400&u=d6f542a910c2290e78b66125ff9c19194b5c5afd&v=4",
+      "feePct": 2
     },
     {
       "chainId": 19,


### PR DESCRIPTION
Json for FlareFrog's Blazeswap logo addition

  {
      "chainId": 14,
      "name": "FlareFrog",
      "symbol": "FLRFROG",
      "decimals": 18,
      "address": "0x19cf770bbb7b71977b860e7fd8d32fa2513a743c",
      "logoURI": "https://avatars.githubusercontent.com/u/200678700?s=400&u=d6f542a910c2290e78b66125ff9c19194b5c5afd&v=4",
      "feePct": 2
    },